### PR TITLE
Try to use AuthenticationServiceInterface for the Identity plugin

### DIFF
--- a/doc/book/index.html
+++ b/doc/book/index.html
@@ -51,8 +51,9 @@ $ composer require zendframework/zend-mvc-plugin-identity
 
       <p>
         For the <code>Identity</code> plugin to work, a
-        <code>Zend\Authentication\AuthenticationService</code> name or alias
-        must be defined and recognized by the <code>ServiceManager</code>.
+        <code>Zend\Authentication\AuthenticationService</code> or
+        <code>Zend\Authentication\AuthenticationServiceInterface</code> name or
+        alias must be defined and recognized by the <code>ServiceManager</code>.
       </p>
 
       <p>
@@ -101,17 +102,35 @@ return [
       </code></pre>
 
       <p>
+        If such service is not found, the plugin will look for a&nbsp;service
+        named <code>Zend\Authentication\AuthenticationServiceInterface</code> in
+        the <code>ServiceManager</code>. For example:
+      </p>
+
+      <pre><code class="lang-php" data-trim>
+use Zend\Authentication\AuthenticationServiceInterface;
+
+return [
+    'service_manager' => [
+        'factories' => [
+            AuthenticationServiceInterface::class => MyAuthenticationServiceFactory::class
+        ]
+    ]
+];
+      </code></pre>
+
+      <p>
         The <code>Identity</code> plugin exposes two methods:
       </p>
 
       <ul>
         <li>
-          <code>setAuthenticationService(AuthenticationService $authenticationService) : void</code>:
+          <code>setAuthenticationService(AuthenticationServiceInterface $authenticationService) : void</code>:
           Sets the authentication service instance to be used by the plugin.
         </li>
 
         <li>
-          <code>getAuthenticationService() : AuthenticationService</code>:
+          <code>getAuthenticationService() : AuthenticationServiceInterface</code>:
           Retrieves the current authentication service instance if any is
           attached.
         </li>

--- a/src/IdentityFactory.php
+++ b/src/IdentityFactory.php
@@ -22,15 +22,15 @@ class IdentityFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        $helper = new Identity();
+        $plugin = new Identity();
 
         if ($container->has(AuthenticationService::class)) {
-            $helper->setAuthenticationService($container->get(AuthenticationService::class));
+            $plugin->setAuthenticationService($container->get(AuthenticationService::class));
         } elseif ($container->has(AuthenticationServiceInterface::class)) {
-            $helper->setAuthenticationService($container->get(AuthenticationServiceInterface::class));
+            $plugin->setAuthenticationService($container->get(AuthenticationServiceInterface::class));
         }
 
-        return $helper;
+        return $plugin;
     }
 
     /**

--- a/src/IdentityFactory.php
+++ b/src/IdentityFactory.php
@@ -9,6 +9,7 @@ namespace Zend\Mvc\Plugin\Identity;
 
 use Interop\Container\ContainerInterface;
 use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\AuthenticationServiceInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -22,9 +23,13 @@ class IdentityFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         $helper = new Identity();
+
         if ($container->has(AuthenticationService::class)) {
             $helper->setAuthenticationService($container->get(AuthenticationService::class));
+        } elseif ($container->has(AuthenticationServiceInterface::class)) {
+            $helper->setAuthenticationService($container->get(AuthenticationServiceInterface::class));
         }
+
         return $helper;
     }
 

--- a/test/IdentityFactoryTest.php
+++ b/test/IdentityFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-mvc-plugin-identity for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mvc-plugin-identity/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Mvc\Plugin\Identity;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\AuthenticationServiceInterface;
+use Zend\Mvc\Plugin\Identity\Identity;
+use Zend\Mvc\Plugin\Identity\IdentityFactory;
+
+class IdentityFactoryTest extends TestCase
+{
+    public function testFactoryReturnsEmptyIdentityIfNoAuthenticationServicePresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(AuthenticationService::class)->willReturn(false);
+        $container->get(AuthenticationService::class)->shouldNotBeCalled();
+        $container->has(AuthenticationServiceInterface::class)->willReturn(false);
+        $container->get(AuthenticationServiceInterface::class)->shouldNotBeCalled();
+
+        $factory = new IdentityFactory();
+        $plugin = $factory($container->reveal(), Identity::class);
+
+        $this->assertInstanceOf(Identity::class, $plugin);
+        $this->assertNull($plugin->getAuthenticationService());
+    }
+
+    public function testFactoryReturnsIdentityWithConfiguredAuthenticationServiceWhenPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $authentication = $this->prophesize(AuthenticationService::class);
+
+        $container->has(AuthenticationService::class)->willReturn(true);
+        $container->get(AuthenticationService::class)->will([$authentication, 'reveal']);
+        $container->has(AuthenticationServiceInterface::class)->willReturn(false);
+        $container->get(AuthenticationServiceInterface::class)->shouldNotBeCalled();
+
+        $factory = new IdentityFactory();
+        $plugin = $factory($container->reveal(), Identity::class);
+
+        $this->assertInstanceOf(Identity::class, $plugin);
+        $this->assertSame($authentication->reveal(), $plugin->getAuthenticationService());
+    }
+
+    public function testFactoryReturnsIdentityWithConfiguredAuthenticationServiceInterfaceWhenPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $authentication = $this->prophesize(AuthenticationServiceInterface::class);
+
+        $container->has(AuthenticationService::class)->willReturn(false);
+        $container->get(AuthenticationService::class)->shouldNotBeCalled();
+        $container->has(AuthenticationServiceInterface::class)->willReturn(true);
+        $container->get(AuthenticationServiceInterface::class)->will([$authentication, 'reveal']);
+
+        $factory = new IdentityFactory();
+        $plugin = $factory($container->reveal(), Identity::class);
+
+        $this->assertInstanceOf(Identity::class, $plugin);
+        $this->assertSame($authentication->reveal(), $plugin->getAuthenticationService());
+    }
+}


### PR DESCRIPTION
Currently, `IdentityFactory` asks the `ServiceManager` to find `AuthenticationService` (the class). It may be useful to also try to find service named `AuthenticationServiceInterface` if the previous one was not found, especially since projects may prefer to typehint to interface rather than to class. Finally, `AuthenticationServiceInterface` defines both methods used by the `Identity` plugin: `hasIdentity` and `getIdentity`.