### PR TITLE
Update docs of the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/.zf-mkdoc-theme-landing export-ignore
 /composer.lock export-ignore
 /docs/ export-ignore
 /mkdocs.yml export-ignore

--- a/README.md
+++ b/README.md
@@ -8,5 +8,28 @@ Provides a
 and up) that allows retrieving the current identity as provided by
 [zend-authentication](https://github.com/zendframework/zend-authentication).
 
-- File issues at https://github.com/zendframework/zend-mvc-plugin-identity/issues
-- Documentation is at https://docs.zendframework.com/zend-mvc-plugin-identity/
+## Installation
+
+Run the following to install this library:
+
+```bash
+$ composer require zendframework/zend-mvc-plugin-identity
+```
+
+If you are using the [zend-component-installer](https://docs.zendframework.com/zend-component-installer),
+you're done!
+
+If not, you will need to add the component as a module to your
+application. Add the entry `'Zend\Mvc\Plugin\Identity'` to
+your list of modules in your application configuration (typically
+one of `config/application.config.php` or `config/modules.config.php`).
+
+## Documentation
+
+Browse the documentation online at https://docs.zendframework.com/zend-mvc-plugin-identity/
+
+## Support
+
+* [Issues](https://github.com/zendframework/zend-mvc-plugin-identity/issues/)
+* [Chat](https://zendframework-slack.herokuapp.com/)
+* [Forum](https://discourse.zendframework.com/)

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -113,9 +113,9 @@ use Zend\Authentication\AuthenticationServiceInterface;
 return [
     'service_manager' => [
         'factories' => [
-            AuthenticationServiceInterface::class => MyAuthenticationServiceFactory::class
-        ]
-    ]
+            AuthenticationServiceInterface::class => MyAuthenticationServiceFactory::class,
+        ],
+    ],
 ];
       </code></pre>
 

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -1,72 +1,51 @@
-<div class="container">
-  <div class="jumbotron">
-    <h1>zend-mvc-plugin-identity</h1>
+<h1>zend-mvc-plugin-identity</h1>
 
-    <p>Plugin for retrieving the current authenticated identity within zend-mvc controllers.</p>
+<p>Plugin for retrieving the current authenticated identity within zend-mvc controllers.</p>
 
-    <pre><code class="language-bash">$ composer require zendframework/zend-mvc-plugin-identity</code></pre>
-  </div>
-</div>
+<h2>Installation</h2>
 
-<div class="container">
-  <div class="row">
-    <div class="col-xs-12 col-sm-6">
-      <div class="panel panel-info">
-        <div class="panel-heading">
-          <h2 class="panel-title">Installation</h2>
-        </div>
+<p>Install via composer:</p>
 
-        <div class="panel-body">
-          <p>
-            Install via composer:
-          </p>
+<pre><code class="language-bash">$ composer require zendframework/zend-mvc-plugin-identity</code></pre>
 
-          <pre><code class="lang-bash" data-trim>
-$ composer require zendframework/zend-mvc-plugin-identity
-          </code></pre>
+<p>
+    If you are using the <a href="https://docs.zendframework.com/zend-component-installer">zend-component-installer</a>,
+    you're done!
+</p>
 
-          <p>
-            If you are using the <a href="https://docs.zendframework.com/zend-component-installer">zend-component-installer</a>,
-            you're done!
-          </p>
+<p>
+    If not, you will need to add the component as a module to your
+    application. Add the entry <code>'Zend\Mvc\Plugin\Identity'</code> to
+    your list of modules in your application configuration (typically
+    one of <code>config/application.config.php</code> or
+    <code>config/modules.config.php</code>).
+</p>
 
-          <p>
-            If not, you will need to add the component as a module to your
-            application. Add the entry <code>'Zend\Mvc\Plugin\Identity'</code> to
-            your list of modules in your application configuration (typically
-            one of <code>config/application.config.php</code> or
-            <code>config/modules.config.php</code>).
-          </p>
-        </div>
-      </div>
-    </div>
+<h2>Usage</h2>
 
-    <div class="col-xs-12 col-sm-6">
-      <h2>Usage</h2>
+<p>
+    The <code>Identity</code> plugin allows retrieving the identity from the
+    <code>AuthenticationService</code>.
+</p>
 
-      <p>
-        The <code>Identity</code> plugin allows retrieving the identity from the
-        <code>AuthenticationService</code>.
-      </p>
+<p>
+    For the <code>Identity</code> plugin to work, a
+    <code>Zend\Authentication\AuthenticationService</code> or
+    <code>Zend\Authentication\AuthenticationServiceInterface</code> name or
+    alias must be defined and recognized by the <code>ServiceManager</code>.
+</p>
 
-      <p>
-        For the <code>Identity</code> plugin to work, a
-        <code>Zend\Authentication\AuthenticationService</code> or
-        <code>Zend\Authentication\AuthenticationServiceInterface</code> name or
-        alias must be defined and recognized by the <code>ServiceManager</code>.
-      </p>
+<p>
+    <code>Identity</code> returns the identity in the
+    <code>AuthenticationService</code> or <code>null</code> if no identity
+    is available.
+</p>
 
-      <p>
-        <code>Identity</code> returns the identity in the
-        <code>AuthenticationService</code> or <code>null</code> if no identity
-        is available.
-      </p>
+<p>
+    As an example:
+</p>
 
-      <p>
-        As an example:
-      </p>
-
-      <pre><code class="lang-php" data-trim>
+<pre><code class="language-php">
 public function testAction()
 {
     if ($user = $this->identity()) {
@@ -75,17 +54,17 @@ public function testAction()
          // not logged in
     }
 }
-      </code></pre>
+</code></pre>
 
-      <p>
-        When invoked, the <code>Identity</code> plugin will look for a service
-        by the name or alias
-        <code>Zend\Authentication\AuthenticationService</code> in the
-        <code>ServiceManager</code>. You can provide this service to the
-        <code>ServiceManager</code> in a configuration file:
-      </p>
+<p>
+    When invoked, the <code>Identity</code> plugin will look for a service
+    by the name or alias
+    <code>Zend\Authentication\AuthenticationService</code> in the
+    <code>ServiceManager</code>. You can provide this service to the
+    <code>ServiceManager</code> in a configuration file:
+</p>
 
-      <pre><code class="lang-php" data-trim>
+<pre><code class="language-php">
 // In a configuration file...
 use Zend\Authentication\AuthenticationService;
 
@@ -99,15 +78,15 @@ return [
         ],
     ],
 ];
-      </code></pre>
+</code></pre>
 
-      <p>
-        If such service is not found, the plugin will look for a&nbsp;service
-        named <code>Zend\Authentication\AuthenticationServiceInterface</code> in
-        the <code>ServiceManager</code>. For example:
-      </p>
+<p>
+    If such service is not found, the plugin will look for a&nbsp;service
+    named <code>Zend\Authentication\AuthenticationServiceInterface</code> in
+    the <code>ServiceManager</code>. For example:
+</p>
 
-      <pre><code class="lang-php" data-trim>
+<pre><code class="language-php">
 use Zend\Authentication\AuthenticationServiceInterface;
 
 return [
@@ -117,24 +96,21 @@ return [
         ],
     ],
 ];
-      </code></pre>
+</code></pre>
 
-      <p>
-        The <code>Identity</code> plugin exposes two methods:
-      </p>
+<p>
+    The <code>Identity</code> plugin exposes two methods:
+</p>
 
-      <ul>
-        <li>
-          <code>setAuthenticationService(AuthenticationServiceInterface $authenticationService) : void</code>:
-          Sets the authentication service instance to be used by the plugin.
-        </li>
+<ul>
+    <li>
+        <code>setAuthenticationService(AuthenticationServiceInterface $authenticationService) : void</code>:
+        Sets the authentication service instance to be used by the plugin.
+    </li>
 
-        <li>
-          <code>getAuthenticationService() : AuthenticationServiceInterface</code>:
-          Retrieves the current authentication service instance if any is
-          attached.
-        </li>
-      </ul>
-    </div>
-  </div>
-</div>
+    <li>
+        <code>getAuthenticationService() : AuthenticationServiceInterface</code>:
+        Retrieves the current authentication service instance if any is
+        attached.
+    </li>
+</ul>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,7 @@
 docs_dir: docs/book
 site_dir: docs/html
-pages:
-    - index.md
+nav:
+    - Home: index.md
 site_name: zend-mvc-plugin-identity
-site_description: 'zend-mvc-plugin-identity: Retrieve the current authenticated identity within a zend-mvc controller'
+site_description: 'Plugin for retrieving the current authenticated identity within zend-mvc controllers'
 repo_url: 'https://github.com/zendframework/zend-mvc-plugin-identity'
-copyright: 'Copyright (c) 2005-2018 <a href="https://www.zend.com/">Zend Technologies USA Inc.</a>'


### PR DESCRIPTION
The whole package documenation is in docs/book/index.html but somehow this
file has not been used on docs.zendframework.com

Adding empty '.zf-mkdoc-theme-landing'

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
